### PR TITLE
arm64: Add 32-bit sigcontext definition to uapi signcontext.h

### DIFF
--- a/arch/arm64/include/uapi/asm/sigcontext.h
+++ b/arch/arm64/include/uapi/asm/sigcontext.h
@@ -16,6 +16,7 @@
 #ifndef _UAPI__ASM_SIGCONTEXT_H
 #define _UAPI__ASM_SIGCONTEXT_H
 
+#ifdef CONFIG_64BIT
 #include <linux/types.h>
 
 /*
@@ -54,4 +55,35 @@ struct fpsimd_context {
 };
 
 
+#else /* CONFIG_64BIT */
+
+/*
+ * Signal context structure - contains all info to do with the state
+ * before the signal handler was invoked.  Note: only add new entries
+ * to the end of the structure.
+ */
+struct sigcontext {
+	unsigned long trap_no;
+	unsigned long error_code;
+	unsigned long oldmask;
+	unsigned long arm_r0;
+	unsigned long arm_r1;
+	unsigned long arm_r2;
+	unsigned long arm_r3;
+	unsigned long arm_r4;
+	unsigned long arm_r5;
+	unsigned long arm_r6;
+	unsigned long arm_r7;
+	unsigned long arm_r8;
+	unsigned long arm_r9;
+	unsigned long arm_r10;
+	unsigned long arm_fp;
+	unsigned long arm_ip;
+	unsigned long arm_sp;
+	unsigned long arm_lr;
+	unsigned long arm_pc;
+	unsigned long arm_cpsr;
+	unsigned long fault_address;
+};
+#endif /* CONFIG_64BIT */
 #endif /* _UAPI__ASM_SIGCONTEXT_H */


### PR DESCRIPTION
The arm64 uapi sigcontext.h can be included by 32-bit userspace
modules.  Since arm and arm64 sigcontext definition are not
compatible, add arm sigcontext definition to arm64 sigcontext.h.

Change-Id: I94109b094f6c8376fdaeb2822d7b26d18ddfb2bc
Signed-off-by: David Ng <dave@codeaurora.org>
Signed-off-by: Divya Sharma <c_shard@codeaurora.org>
Signed-off-by: Anh Nguyen <anguyen@codeaurora.org>